### PR TITLE
parallel marking

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -45,8 +45,8 @@ RUNTIME_SRCS := \
 	jltypes gf typemap smallintset ast builtins module interpreter symbol \
 	dlload sys init task array dump staticdata toplevel jl_uv datatype \
 	simplevector runtime_intrinsics precompile \
-	threading partr stackwalk gc gc-debug gc-pages gc-stacks gc-alloc-profiler method \
-	jlapi signal-handling safepoint timing subtype \
+	threading partr stackwalk gc gc-debug gc-pages gc-stacks gc-alloc-profiler wsqueue \
+	method jlapi signal-handling safepoint timing subtype \
 	crc32c APInt-C processor ircode opaque_closure codegen-stubs coverage
 SRCS := jloptions runtime_ccall rtutils
 ifeq ($(OS),WINNT)
@@ -104,7 +104,7 @@ ifeq ($(USE_SYSTEM_LIBUV),0)
 UV_HEADERS += uv.h
 UV_HEADERS += uv/*.h
 endif
-PUBLIC_HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h jloptions.h)
+PUBLIC_HEADERS := $(BUILDDIR)/julia_version.h $(wildcard $(SRCDIR)/support/*.h) $(addprefix $(SRCDIR)/,julia.h julia_assert.h julia_threads.h julia_fasttls.h julia_locks.h julia_atomics.h jloptions.h wsqueue.h)
 ifeq ($(OS),WINNT)
 PUBLIC_HEADERS += $(addprefix $(SRCDIR)/,win32_ucontext.h)
 endif

--- a/src/gc-debug.c
+++ b/src/gc-debug.c
@@ -198,50 +198,50 @@ static void restore(void)
 
 static void gc_verify_track(jl_ptls_t ptls)
 {
-    do {
-        jl_gc_markqueue_t mq;
-        mq.current = mq.start = (ptls->mark_queue).start;
-        mq.end = (ptls->mark_queue).end;
-        arraylist_push(&lostval_parents_done, lostval);
-        jl_safe_printf("Now looking for %p =======\n", lostval);
-        clear_mark(GC_CLEAN);
-        gc_mark_queue_all_roots(ptls, &mq);
-        gc_mark_finlist(&mq, &to_finalize, 0);
-        for (int i = 0;i < jl_n_threads;i++) {
-            jl_ptls_t ptls2 = jl_all_tls_states[i];
-            gc_mark_finlist(&mq, &ptls2->finalizers, 0);
-        }
-        gc_mark_finlist(&mq, &finalizer_list_marked, 0);
-        gc_mark_loop_(ptls, &mq);
-        if (lostval_parents.len == 0) {
-            jl_safe_printf("Could not find the missing link. We missed a toplevel root. This is odd.\n");
-            break;
-        }
-        jl_value_t *lostval_parent = NULL;
-        for(int i = 0; i < lostval_parents.len; i++) {
-            lostval_parent = (jl_value_t*)lostval_parents.items[i];
-            int clean_len = bits_save[GC_CLEAN].len;
-            for(int j = 0; j < clean_len + bits_save[GC_OLD].len; j++) {
-                void *p = bits_save[j >= clean_len ? GC_OLD : GC_CLEAN].items[j >= clean_len ? j - clean_len : j];
-                if (jl_valueof(p) == lostval_parent) {
-                    lostval = lostval_parent;
-                    lostval_parent = NULL;
-                    break;
-                }
-            }
-            if (lostval_parent != NULL) break;
-        }
-        if (lostval_parent == NULL) { // all parents of lostval were also scheduled for deletion
-            lostval = (jl_value_t*)arraylist_pop(&lostval_parents);
-        }
-        else {
-            jl_safe_printf("Missing write barrier found !\n");
-            jl_safe_printf("%p was written a reference to %p that was not recorded\n", lostval_parent, lostval);
-            jl_safe_printf("(details above)\n");
-            lostval = NULL;
-        }
-        restore();
-    } while(lostval != NULL);
+    // do {
+    //     jl_gc_markqueue_t mq;
+    //     mq.current = mq.start = (ptls->mark_queue).start;
+    //     mq.end = (ptls->mark_queue).end;
+    //     arraylist_push(&lostval_parents_done, lostval);
+    //     jl_safe_printf("Now looking for %p =======\n", lostval);
+    //     clear_mark(GC_CLEAN);
+    //     gc_mark_queue_all_roots(ptls, &mq);
+    //     gc_mark_finlist(&mq, &to_finalize, 0);
+    //     for (int i = 0;i < jl_n_threads;i++) {
+    //         jl_ptls_t ptls2 = jl_all_tls_states[i];
+    //         gc_mark_finlist(&mq, &ptls2->finalizers, 0);
+    //     }
+    //     gc_mark_finlist(&mq, &finalizer_list_marked, 0);
+    //     gc_mark_loop_(ptls, &mq);
+    //     if (lostval_parents.len == 0) {
+    //         jl_safe_printf("Could not find the missing link. We missed a toplevel root. This is odd.\n");
+    //         break;
+    //     }
+    //     jl_value_t *lostval_parent = NULL;
+    //     for(int i = 0; i < lostval_parents.len; i++) {
+    //         lostval_parent = (jl_value_t*)lostval_parents.items[i];
+    //         int clean_len = bits_save[GC_CLEAN].len;
+    //         for(int j = 0; j < clean_len + bits_save[GC_OLD].len; j++) {
+    //             void *p = bits_save[j >= clean_len ? GC_OLD : GC_CLEAN].items[j >= clean_len ? j - clean_len : j];
+    //             if (jl_valueof(p) == lostval_parent) {
+    //                 lostval = lostval_parent;
+    //                 lostval_parent = NULL;
+    //                 break;
+    //             }
+    //         }
+    //         if (lostval_parent != NULL) break;
+    //     }
+    //     if (lostval_parent == NULL) { // all parents of lostval were also scheduled for deletion
+    //         lostval = (jl_value_t*)arraylist_pop(&lostval_parents);
+    //     }
+    //     else {
+    //         jl_safe_printf("Missing write barrier found !\n");
+    //         jl_safe_printf("%p was written a reference to %p that was not recorded\n", lostval_parent, lostval);
+    //         jl_safe_printf("(details above)\n");
+    //         lostval = NULL;
+    //     }
+    //     restore();
+    // } while(lostval != NULL);
 }
 
 void gc_verify(jl_ptls_t ptls)
@@ -1272,24 +1272,24 @@ int gc_slot_to_arrayidx(void *obj, void *_slot)
 // `offset` will be added to `mq->current` for convenience in the debugger.
 NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, jl_gc_markqueue_t *mq, int offset)
 {
-    jl_jmp_buf *old_buf = jl_get_safe_restore();
-    jl_jmp_buf buf;
-    jl_set_safe_restore(&buf);
-    if (jl_setjmp(buf, 0) != 0) {
-        jl_safe_printf("\n!!! ERROR when unwinding gc mark loop -- ABORTING !!!\n");
-        jl_set_safe_restore(old_buf);
-        return;
-    }
-    jl_value_t **start = mq->start;
-    jl_value_t **end = mq->current + offset;
-    for (; start < end; start++) {
-        jl_value_t *obj = *start;
-        jl_taggedvalue_t *o = jl_astaggedvalue(obj);
-        jl_safe_printf("Queued object: %p :: (header: %zu) (bits: %zu)\n", obj, (uintptr_t)o->header,
-                        ((uintptr_t)o->header & 3));
-        jl_((void*)(jl_datatype_t *)(o->header & ~(uintptr_t)0xf));
-    }
-    jl_set_safe_restore(old_buf);
+    // jl_jmp_buf *old_buf = jl_get_safe_restore();
+    // jl_jmp_buf buf;
+    // jl_set_safe_restore(&buf);
+    // if (jl_setjmp(buf, 0) != 0) {
+    //     jl_safe_printf("\n!!! ERROR when unwinding gc mark loop -- ABORTING !!!\n");
+    //     jl_set_safe_restore(old_buf);
+    //     return;
+    // }
+    // jl_value_t **start = mq->start;
+    // jl_value_t **end = mq->current + offset;
+    // for (; start < end; start++) {
+    //     jl_value_t *obj = *start;
+    //     jl_taggedvalue_t *o = jl_astaggedvalue(obj);
+    //     jl_safe_printf("Queued object: %p :: (header: %zu) (bits: %zu)\n", obj, (uintptr_t)o->header,
+    //                     ((uintptr_t)o->header & 3));
+    //     jl_((void*)(jl_datatype_t *)(o->header & ~(uintptr_t)0xf));
+    // }
+    // jl_set_safe_restore(old_buf);
 }
 
 static int gc_logging_enabled = 0;

--- a/src/gc.h
+++ b/src/gc.h
@@ -500,7 +500,7 @@ extern int gc_verifying;
 #endif
 int gc_slot_to_fieldidx(void *_obj, void *slot);
 int gc_slot_to_arrayidx(void *_obj, void *begin);
-NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, jl_gc_markqueue_t *mq, int pc_offset);
+NOINLINE void gc_mark_loop_unwind(jl_ptls_t ptls, jl_gc_markqueue_t *mq, int offset) JL_NOTSAFEPOINT;
 
 #ifdef GC_DEBUG_ENV
 JL_DLLEXPORT extern jl_gc_debug_env_t jl_gc_debug_env;

--- a/src/julia_gcext.h
+++ b/src/julia_gcext.h
@@ -35,7 +35,7 @@ JL_DLLEXPORT void jl_gc_set_cb_notify_external_free(jl_gc_cb_notify_external_fre
         int enable);
 
 // Types for custom mark and sweep functions.
-typedef uintptr_t (*jl_markfunc_t)(jl_ptls_t, jl_value_t *obj);
+typedef uintptr_t (*jl_markfunc_t)(jl_ptls_t, jl_value_t *obj) JL_NOTSAFEPOINT;
 typedef void (*jl_sweepfunc_t)(jl_value_t *obj);
 
 // Function to create a new foreign type with custom

--- a/src/partr.c
+++ b/src/partr.c
@@ -54,9 +54,6 @@ uint64_t io_wakeup_enter;
 uint64_t io_wakeup_leave;
 );
 
-uv_mutex_t *sleep_locks;
-uv_cond_t *wake_signals;
-
 JL_DLLEXPORT int jl_set_task_tid(jl_task_t *task, int16_t tid) JL_NOTSAFEPOINT
 {
     // Try to acquire the lock on this task.
@@ -107,14 +104,6 @@ void jl_init_threadinginfra(void)
 
     jl_ptls_t ptls = jl_current_task->ptls;
     jl_install_thread_signal_handler(ptls);
-
-    int16_t tid;
-    sleep_locks = (uv_mutex_t*)calloc(jl_n_threads, sizeof(uv_mutex_t));
-    wake_signals = (uv_cond_t*)calloc(jl_n_threads, sizeof(uv_cond_t));
-    for (tid = 0; tid < jl_n_threads; tid++) {
-        uv_mutex_init(&sleep_locks[tid]);
-        uv_cond_init(&wake_signals[tid]);
-    }
 }
 
 
@@ -204,9 +193,9 @@ static int wake_thread(int16_t tid)
     if (jl_atomic_load_relaxed(&other->sleep_check_state) == sleeping) {
         if (jl_atomic_cmpswap_relaxed(&other->sleep_check_state, &state, not_sleeping)) {
             JL_PROBE_RT_SLEEP_CHECK_WAKE(other, state);
-            uv_mutex_lock(&sleep_locks[tid]);
-            uv_cond_signal(&wake_signals[tid]);
-            uv_mutex_unlock(&sleep_locks[tid]);
+            uv_mutex_lock(&other->sleep_lock);
+            uv_cond_signal(&other->wake_signal);
+            uv_mutex_unlock(&other->sleep_lock);
             return 1;
         }
     }
@@ -418,13 +407,13 @@ JL_DLLEXPORT jl_task_t *jl_task_get_next(jl_value_t *trypoptask, jl_value_t *q, 
             // the other threads will just wait for an individual wake signal to resume
             JULIA_DEBUG_SLEEPWAKE( ptls->sleep_enter = cycleclock() );
             int8_t gc_state = jl_gc_safe_enter(ptls);
-            uv_mutex_lock(&sleep_locks[ptls->tid]);
+            uv_mutex_lock(&ptls->sleep_lock);
             while (may_sleep(ptls)) {
-                uv_cond_wait(&wake_signals[ptls->tid], &sleep_locks[ptls->tid]);
-                // TODO: help with gc work here, if applicable
+                uv_cond_wait(&ptls->wake_signal, &ptls->sleep_lock);
+                jl_spinmaster_wait_gc();
             }
             assert(jl_atomic_load_relaxed(&ptls->sleep_check_state) == not_sleeping);
-            uv_mutex_unlock(&sleep_locks[ptls->tid]);
+            uv_mutex_unlock(&ptls->sleep_lock);
             JULIA_DEBUG_SLEEPWAKE( ptls->sleep_leave = cycleclock() );
             jl_gc_safe_leave(ptls, gc_state); // contains jl_gc_safepoint
             start_cycles = 0;

--- a/src/safepoint.c
+++ b/src/safepoint.c
@@ -43,6 +43,13 @@ uint8_t jl_safepoint_enable_cnt[3] = {0, 0, 0};
 // load/store so that threads waiting for the GC doesn't have to also
 // fight on the safepoint lock...
 uv_mutex_t safepoint_lock;
+uv_cond_t safepoint_cond;
+
+jl_mutex_t spinmaster_lock;
+const uint64_t timeout_ns = 1e5;
+
+extern _Atomic(int32_t) nworkers_marking;
+extern void gc_mark_loop(jl_ptls_t ptls) JL_NOTSAFEPOINT;
 
 static void jl_safepoint_enable(int idx) JL_NOTSAFEPOINT
 {
@@ -87,6 +94,7 @@ static void jl_safepoint_disable(int idx) JL_NOTSAFEPOINT
 void jl_safepoint_init(void)
 {
     uv_mutex_init(&safepoint_lock);
+    uv_cond_init(&safepoint_cond);
     // jl_page_size isn't available yet.
     size_t pgsz = jl_getpagesize();
 #ifdef _OS_WINDOWS_
@@ -123,7 +131,7 @@ int jl_safepoint_start_gc(void)
     uint32_t running = 0;
     if (!jl_atomic_cmpswap(&jl_gc_running, &running, 1)) {
         uv_mutex_unlock(&safepoint_lock);
-        jl_safepoint_wait_gc();
+        jl_spinmaster_wait_gc();
         return 0;
     }
     jl_safepoint_enable(1);
@@ -146,21 +154,119 @@ void jl_safepoint_end_gc(void)
     jl_safepoint_disable(2);
     jl_safepoint_disable(1);
     jl_atomic_store_release(&jl_gc_running, 0);
-#  ifdef __APPLE__
-    // This wakes up other threads on mac.
-    jl_mach_gc_end();
-#  endif
+    uv_mutex_unlock(&safepoint_lock);
+    uv_cond_broadcast(&safepoint_cond);
+}
+
+// Thread recruitment scheme inspired by Hassanein's "spin-master",
+// `Understanding and Improving JVM GC Work Stealing at the
+// Data Center Scale`
+
+int jl_spinmaster_all_workers_done(jl_ptls_t ptls) JL_NOTSAFEPOINT
+{
+    return (jl_atomic_load_acquire(&nworkers_marking) == 0);
+}
+
+#ifndef GC_VERIFY
+int64_t jl_spinmaster_count_work(jl_ptls_t ptls) JL_NOTSAFEPOINT
+{
+    int64_t work = 0;
+    for (int i = 0; i < jl_n_threads; i++) {
+        jl_ptls_t ptls2 = jl_all_tls_states[i];
+        jl_gc_markqueue_t *mq2 = &ptls2->mark_queue;
+        ws_queue_t *q2 = &mq2->q;
+        // This count can be slightly off, but it doesn't matter
+        // for recruitment heuristics
+        int64_t t2 = jl_atomic_load_relaxed(&q2->top);
+        int64_t b2 = jl_atomic_load_relaxed(&q2->bottom);
+        work += b2 - t2;
+    }
+    return work;
+}
+
+void jl_spinmaster_notify_all(jl_ptls_t ptls) JL_NOTSAFEPOINT
+{
+    for (int i = 0; i < jl_n_threads; i++) {
+        if (i == ptls->tid)
+            continue;
+        jl_ptls_t ptls2 = jl_all_tls_states[i];
+        uv_cond_signal(&ptls2->gc_wake_signal);
+    }
+}
+
+void jl_spinmaster_recruit_workers(jl_ptls_t ptls, size_t nworkers) JL_NOTSAFEPOINT
+{
+    for (int i = 0; i < jl_n_threads && nworkers > 0; i++) {
+        if (i == ptls->tid)
+            continue;
+        jl_ptls_t ptls2 = jl_all_tls_states[i];
+        if (jl_atomic_load_acquire(&ptls2->gc_state) == JL_GC_STATE_WAITING) {
+            uv_cond_signal(&ptls2->gc_wake_signal);
+            nworkers--;
+        }
+    }
+}
+#endif
+
+int jl_spinmaster_end_marking(jl_ptls_t ptls) JL_NOTSAFEPOINT
+{
+    // Fast path for mark-loop termination
+    if (jl_spinmaster_all_workers_done(ptls)) {
+        return 1;
+    }
+#ifndef GC_VERIFY
+    if (jl_mutex_trylock_nogc(&spinmaster_lock)) {
+        spin : {
+            if (!jl_spinmaster_all_workers_done(ptls)) {
+                int64_t work = jl_spinmaster_count_work(ptls);
+                if (work > 1) {
+                    jl_spinmaster_recruit_workers(ptls, work - 1);
+                    jl_mutex_unlock_nogc(&spinmaster_lock);
+                    gc_mark_loop(ptls);
+                    return 0;
+                }
+                jl_cpu_pause();
+                goto spin;
+            }
+        }
+        jl_spinmaster_notify_all(ptls);
+        jl_mutex_unlock_nogc(&spinmaster_lock);
+        return 1;
+    }
+#endif
+    return 0;
+}
+
+void jl_spinmaster_wait_pmark(void) JL_NOTSAFEPOINT
+{
+    jl_ptls_t ptls = jl_current_task->ptls;
+    while(!jl_spinmaster_end_marking(ptls)) {
+        uv_mutex_lock(&ptls->gc_sleep_lock);
+        int ret = uv_cond_timedwait(&ptls->gc_wake_signal,
+                                    &ptls->gc_sleep_lock, timeout_ns);
+        uv_mutex_unlock(&ptls->gc_sleep_lock);
+        if (ret == 0)
+            gc_mark_loop(ptls);
+    }
+}
+
+void jl_spinmaster_wait_sweeping(void) JL_NOTSAFEPOINT
+{
+    // Use system mutexes rather than spin locking to minimize wasted CPU
+    // time on the idle cores while we wait for the GC to finish.
+    // This is particularly important when run under rr.
+    uv_mutex_lock(&safepoint_lock);
+    if (jl_atomic_load_relaxed(&jl_gc_running))
+        uv_cond_wait(&safepoint_cond, &safepoint_lock);
     uv_mutex_unlock(&safepoint_lock);
 }
 
-void jl_safepoint_wait_gc(void)
+void jl_spinmaster_wait_gc(void) JL_NOTSAFEPOINT
 {
-    // The thread should have set this is already
-    assert(jl_atomic_load_relaxed(&jl_current_task->ptls->gc_state) != 0);
-    // Use normal volatile load in the loop for speed until GC finishes.
-    // Then use an acquire load to make sure the GC result is visible on this thread.
-    while (jl_atomic_load_relaxed(&jl_gc_running) || jl_atomic_load_acquire(&jl_gc_running)) {
-        jl_cpu_pause(); // yield?
+    while (jl_atomic_load_relaxed(&jl_gc_running) ||
+           jl_atomic_load_acquire(&jl_gc_running)) {
+        jl_spinmaster_wait_pmark();
+        jl_spinmaster_wait_sweeping();
     }
 }
 

--- a/src/signals-mach.c
+++ b/src/signals-mach.c
@@ -38,45 +38,6 @@ extern void _dyld_atfork_parent(void) __attribute__((weak_import));
 
 static void attach_exception_port(thread_port_t thread, int segv_only);
 
-// low 16 bits are the thread id, the next 8 bits are the original gc_state
-static arraylist_t suspended_threads;
-void jl_mach_gc_end(void)
-{
-    // Requires the safepoint lock to be held
-    for (size_t i = 0; i < suspended_threads.len; i++) {
-        uintptr_t item = (uintptr_t)suspended_threads.items[i];
-        int16_t tid = (int16_t)item;
-        int8_t gc_state = (int8_t)(item >> 8);
-        jl_ptls_t ptls2 = jl_all_tls_states[tid];
-        jl_atomic_store_release(&ptls2->gc_state, gc_state);
-        thread_resume(pthread_mach_thread_np(ptls2->system_id));
-    }
-    suspended_threads.len = 0;
-}
-
-// Suspend the thread and return `1` if the GC is running.
-// Otherwise return `0`
-static int jl_mach_gc_wait(jl_ptls_t ptls2,
-                           mach_port_t thread, int16_t tid)
-{
-    uv_mutex_lock(&safepoint_lock);
-    if (!jl_atomic_load_relaxed(&jl_gc_running)) {
-        // relaxed, since gets set to zero only while the safepoint_lock was held
-        // this means we can tell if GC is done before we got the message or
-        // the safepoint was enabled for SIGINT.
-        uv_mutex_unlock(&safepoint_lock);
-        return 0;
-    }
-    // Otherwise, set the gc state of the thread, suspend and record it
-    int8_t gc_state = ptls2->gc_state;
-    jl_atomic_store_release(&ptls2->gc_state, JL_GC_STATE_WAITING);
-    uintptr_t item = tid | (((uintptr_t)gc_state) << 16);
-    arraylist_push(&suspended_threads, (void*)item);
-    thread_suspend(thread);
-    uv_mutex_unlock(&safepoint_lock);
-    return 1;
-}
-
 static mach_port_t segv_port = 0;
 
 extern boolean_t exc_server(mach_msg_header_t *, mach_msg_header_t *);
@@ -110,7 +71,6 @@ static void allocate_mach_handler()
     if (_keymgr_set_lockmode_processwide_ptr(KEYMGR_GCC3_DW2_OBJ_LIST, NM_ALLOW_RECURSION))
         jl_error("_keymgr_set_lockmode_processwide_ptr failed");
 
-    arraylist_new(&suspended_threads, jl_n_threads);
     pthread_t thread;
     pthread_attr_t attr;
     kern_return_t ret;
@@ -229,10 +189,23 @@ static void jl_throw_in_thread(int tid, mach_port_t thread, jl_value_t *exceptio
 static void segv_handler(int sig, siginfo_t *info, void *context)
 {
     assert(sig == SIGSEGV || sig == SIGBUS);
+    jl_task_t *ct = jl_get_current_task();
     if (jl_get_safe_restore()) { // restarting jl_ or jl_unwind_stepn
-        jl_task_t *ct = jl_get_current_task();
         jl_ptls_t ptls = ct == NULL ? NULL : ct->ptls;
         jl_call_in_state(ptls, (host_thread_state_t*)jl_to_bt_context(context), &jl_sig_throw);
+    }
+    else if (jl_addr_is_safepoint((uintptr_t)info->si_addr)) {
+        jl_set_gc_and_wait();
+        // Do not raise sigint on worker thread
+        if (jl_atomic_load_relaxed(&ct->tid) != 0)
+            return;
+        if (ct->ptls->defer_signal) {
+            jl_safepoint_defer_sigint();
+        }
+        else if (jl_safepoint_consume_sigint()) {
+            jl_clear_force_sigint();
+            jl_throw_in_ctx(ct, jl_interrupt_exception, sig, context);
+        }
     }
     else {
         sigdie_handler(sig, info, context);
@@ -284,10 +257,12 @@ kern_return_t catch_exception_raise(mach_port_t            exception_port,
     uint64_t fault_addr = exc_state.__far;
 #endif
     if (jl_addr_is_safepoint(fault_addr)) {
-        if (jl_mach_gc_wait(ptls2, thread, tid))
+        if (jl_atomic_load_acquire(&jl_gc_running))
+            // Fallback to POSIX signals and handle GC thread recruitment there
+            return KERN_FAILURE;
+        if (ptls2->tid != 0) {
             return KERN_SUCCESS;
-        if (ptls2->tid != 0)
-            return KERN_SUCCESS;
+        }
         if (ptls2->defer_signal) {
             jl_safepoint_defer_sigint();
         }

--- a/src/threading.c
+++ b/src/threading.c
@@ -343,6 +343,12 @@ jl_ptls_t jl_init_threadtls(int16_t tid)
     small_arraylist_new(&ptls->locks, 0);
     jl_init_thread_heap(ptls);
 
+    uv_mutex_init(&ptls->sleep_lock);
+    uv_mutex_init(&ptls->gc_sleep_lock);
+
+    uv_cond_init(&ptls->wake_signal);
+    uv_cond_init(&ptls->gc_wake_signal);
+
     jl_all_tls_states[tid] = ptls;
 
     return ptls;

--- a/src/wsqueue.c
+++ b/src/wsqueue.c
@@ -1,0 +1,128 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#include <stdlib.h>
+#include "julia.h"
+#include "wsqueue.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+ws_array_t *create_ws_array(size_t capacity, size_t eltsz)
+{
+    ws_array_t *a = (ws_array_t *)malloc_s(sizeof(ws_array_t));
+    a->buffer = (void **)malloc_s(capacity * eltsz);
+    a->capacity = capacity;
+    return a;
+}
+
+// ---------- Chase-Lev work-stealing queue
+
+int ws_queue_push(ws_queue_t *q, void *v)
+{
+    int64_t b = jl_atomic_load_relaxed(&q->bottom);
+    int64_t t = jl_atomic_load_acquire(&q->top);
+    ws_array_t *a = jl_atomic_load_relaxed(&q->array);
+    if (__unlikely(b - t > a->capacity - 1)) {
+        // Queue is full
+        return 0;
+    }
+    jl_atomic_store_relaxed((_Atomic(void *) *)&a->buffer[b % a->capacity], v);
+    jl_fence_release();
+    jl_atomic_store_relaxed(&q->bottom, b + 1);
+    return 1;
+}
+
+void *ws_queue_pop(ws_queue_t *q)
+{
+    int64_t b = jl_atomic_load_relaxed(&q->bottom) - 1;
+    ws_array_t *a = jl_atomic_load_relaxed(&q->array);
+    jl_atomic_store_relaxed(&q->bottom, b);
+#if defined(_CPU_X86_64_)
+    __asm__ volatile ("lock orq $0, (%rsp)");
+#else
+    jl_fence();
+#endif
+    int64_t t = jl_atomic_load_relaxed(&q->top);
+    void *v;
+    if (__likely(t <= b)) {
+        v = jl_atomic_load_relaxed((_Atomic(void *) *)&a->buffer[b % a->capacity]);
+        if (t == b) {
+            if (!jl_atomic_cmpswap(&q->top, &t, t + 1))
+                v = NULL;
+            jl_atomic_store_relaxed(&q->bottom, b + 1);
+        }
+    }
+    else {
+        v = NULL;
+        jl_atomic_store_relaxed(&q->bottom, b + 1);
+    }
+    return v;
+}
+
+void *ws_queue_steal_from(ws_queue_t *q)
+{
+    int64_t t = jl_atomic_load_acquire(&q->top);
+#if defined(_CPU_X86_64_)
+    __asm__ volatile ("lock orq $0, (%rsp)");
+#else
+    jl_fence();
+#endif
+    int64_t b = jl_atomic_load_acquire(&q->bottom);
+    void *v = NULL;
+    if (t < b) {
+        ws_array_t *a = jl_atomic_load_relaxed(&q->array);
+        v = jl_atomic_load_relaxed((_Atomic(void *) *)&a->buffer[t % a->capacity]);
+        if (!jl_atomic_cmpswap(&q->top, &t, t + 1))
+            return NULL;
+    }
+    return v;
+}
+
+// ---------- Idempotent work-stealing queue
+
+int idemp_ws_queue_push(idemp_ws_queue_t *iwsq, void *elt)
+{
+    ws_anchor_t anc = jl_atomic_load_acquire(&iwsq->anchor);
+    ws_array_t *ary = jl_atomic_load_relaxed(&iwsq->array);
+    if (anc.tail == ary->capacity)
+        // Queue overflow
+        return 0;
+    ary->buffer[anc.tail] = elt;
+    anc.tail++;
+    anc.tag++;
+    jl_atomic_store_release(&iwsq->anchor, anc);
+    return 1;
+}
+
+void *idemp_ws_queue_pop(idemp_ws_queue_t *iwsq)
+{
+    ws_anchor_t anc = jl_atomic_load_acquire(&iwsq->anchor);
+    ws_array_t *ary = jl_atomic_load_relaxed(&iwsq->array);
+    if (anc.tail == 0)
+        // Empty queue
+        return NULL;
+    anc.tail--;
+    void *elt = ary->buffer[anc.tail];
+    jl_atomic_store_release(&iwsq->anchor, anc);
+    return elt;
+}
+
+void *idemp_ws_queue_steal_from(idemp_ws_queue_t *iwsq)
+{
+    ws_anchor_t anc = jl_atomic_load_acquire(&iwsq->anchor);
+    ws_array_t *ary = jl_atomic_load_acquire(&iwsq->array);
+    if (anc.tail == 0)
+        // Empty queue
+        return NULL;
+    void *elt = ary->buffer[anc.tail - 1];
+    ws_anchor_t anc2 = {anc.tail - 1, anc.tag};
+    if (!jl_atomic_cmpswap(&iwsq->anchor, &anc, anc2))
+        // Steal failed
+        return NULL;
+    return elt;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/wsqueue.h
+++ b/src/wsqueue.h
@@ -1,0 +1,66 @@
+// This file is a part of Julia. License is MIT: https://julialang.org/license
+
+#ifndef WS_QUEUE_H
+#define WS_QUEUE_H
+
+#include "julia_atomics.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+    void **buffer;
+    int64_t capacity;
+} ws_array_t;
+
+ws_array_t *create_ws_array(size_t capacity, size_t eltsz) JL_NOTSAFEPOINT;
+
+// =======
+// Chase and Lev's work-stealing queue, optimized for
+// weak memory models by Le et al.
+//
+// * Chase D., Lev Y. Dynamic Circular Work-Stealing queue
+// * Le N. M. et al. Correct and Efficient Work-Stealing for
+//   Weak Memory Models
+// =======
+
+typedef struct {
+    _Atomic(int64_t) top;
+    _Atomic(int64_t) bottom;
+    _Atomic(ws_array_t *) array;
+} ws_queue_t;
+
+int ws_queue_push(ws_queue_t *dq, void *elt) JL_NOTSAFEPOINT;
+
+void *ws_queue_pop(ws_queue_t *dq) JL_NOTSAFEPOINT;
+
+void *ws_queue_steal_from(ws_queue_t *dq) JL_NOTSAFEPOINT;
+
+// =======
+// Idempotent work-stealing deque
+//
+// * Michael M. M. et al. Idempotent Work Stealing
+// =======
+
+typedef struct {
+    int32_t tail;
+    int32_t tag;
+} ws_anchor_t;
+
+typedef struct {
+    _Atomic(ws_anchor_t) anchor;
+    _Atomic(ws_array_t *) array;
+} idemp_ws_queue_t;
+
+int idemp_ws_queue_push(idemp_ws_queue_t *iwsq, void *elt) JL_NOTSAFEPOINT;
+
+void *idemp_ws_queue_pop(idemp_ws_queue_t *iwsq) JL_NOTSAFEPOINT;
+
+void *idemp_ws_queue_steal_from(idemp_ws_queue_t *iwsq) JL_NOTSAFEPOINT;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
This PR still runs GC in the signal handler, so it's unable to resize work-stealing queues of GC items.

Scales for `tree.jl` from `GCBenchmarks`.